### PR TITLE
use ascii name instead of chinese to fix electron (win & macOS) update bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "无名杀",
+  "name": "noname",
   "version": "1.9.0",
   "main": "main.js"
 }


### PR DESCRIPTION
the name will be part in the Electron's User-Agent.
And, the HTTP header can only be ascii character.
So, the update/new download cannot work.